### PR TITLE
F/bump injective std

### DIFF
--- a/packages/injective-test-tube/CHANGELOG.md
+++ b/packages/injective-test-tube/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.2.1 - 2024-06-06
+
+### Changed
+
+- Updated:
+  - injective-std
+  - prost
+
 ## 1.2.0 - 2024-02-05
 
 ### Changed

--- a/packages/injective-test-tube/Cargo.toml
+++ b/packages/injective-test-tube/Cargo.toml
@@ -15,8 +15,8 @@ cosmrs             = { version = "0.15.0", features = [ "cosmwasm", "rpc" ] }
 cosmwasm-std       = { version = "1.5.4", features = [ "abort", "cosmwasm_1_2", "cosmwasm_1_3", "cosmwasm_1_4", "iterator", "stargate" ] }
 hex                = "0.4.2"
 injective-cosmwasm = { version = "0.2.18" }
-injective-std      = { version = "0.1.7" }
-prost              = "0.12.3"
+injective-std      = { version = "1.12.10-testnet-rc2.1" }
+prost              = "0.12.4"
 serde              = "1.0.144"
 serde_json         = "1.0.85"
 test-tube-inj      = { version = "1.1.4" }

--- a/packages/injective-test-tube/Cargo.toml
+++ b/packages/injective-test-tube/Cargo.toml
@@ -15,11 +15,11 @@ cosmrs             = { version = "0.15.0", features = [ "cosmwasm", "rpc" ] }
 cosmwasm-std       = { version = "1.5.4", features = [ "abort", "cosmwasm_1_2", "cosmwasm_1_3", "cosmwasm_1_4", "iterator", "stargate" ] }
 hex                = "0.4.2"
 injective-cosmwasm = { version = "0.2.18" }
-injective-std      = { version = "1.12.10-testnet-rc2.1" }
+injective-std      = { version = "0.1.8" }
 prost              = "0.12.4"
 serde              = "1.0.144"
 serde_json         = "1.0.85"
-test-tube-inj      = { version = "1.1.4" }
+test-tube-inj      = { version = "1.1.5" }
 thiserror          = "1.0.34"
 
 [build-dependencies]

--- a/packages/injective-test-tube/Cargo.toml
+++ b/packages/injective-test-tube/Cargo.toml
@@ -4,7 +4,7 @@ edition     = "2021"
 license     = "MIT OR Apache-2.0"
 name        = "injective-test-tube"
 repository  = "https://github.com/InjectiveLabs/test-tube"
-version     = "1.2.0"
+version     = "1.2.1"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 exclude = [ "injective-core", "test_artifacts" ]

--- a/packages/injective-test-tube/src/module/exchange.rs
+++ b/packages/injective-test-tube/src/module/exchange.rs
@@ -178,7 +178,6 @@ mod tests {
                     quote_denom: "usdt".to_owned(),
                     min_price_tick_size: "10000".to_owned(),
                     min_quantity_tick_size: "100000".to_owned(),
-                    min_notional: "1000000000000000000".to_owned(),
                 },
                 &signer,
             )
@@ -193,7 +192,6 @@ mod tests {
                     quote_denom: "usdt".to_owned(),
                     min_price_tick_size: "10000".to_owned(),
                     min_quantity_tick_size: "100000".to_owned(),
-                    min_notional: "1000000000000000000".to_owned(),
                 },
                 &signer,
             )

--- a/packages/injective-test-tube/src/module/exchange.rs
+++ b/packages/injective-test-tube/src/module/exchange.rs
@@ -178,6 +178,7 @@ mod tests {
                     quote_denom: "usdt".to_owned(),
                     min_price_tick_size: "10000".to_owned(),
                     min_quantity_tick_size: "100000".to_owned(),
+                    min_notional: "1000000000000000000".to_owned(),
                 },
                 &signer,
             )
@@ -192,6 +193,7 @@ mod tests {
                     quote_denom: "usdt".to_owned(),
                     min_price_tick_size: "10000".to_owned(),
                     min_quantity_tick_size: "100000".to_owned(),
+                    min_notional: "1000000000000000000".to_owned(),
                 },
                 &signer,
             )

--- a/packages/test-tube/Cargo.toml
+++ b/packages/test-tube/Cargo.toml
@@ -4,7 +4,7 @@ edition     = "2021"
 license     = "MIT OR Apache-2.0"
 name        = "test-tube-inj"
 repository  = "https://github.com/InjectiveLabs/test-tube"
-version     = "1.1.4"
+version     = "1.1.5"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/packages/test-tube/Cargo.toml
+++ b/packages/test-tube/Cargo.toml
@@ -12,7 +12,7 @@ version     = "1.1.4"
 base64           = "0.21.5"
 cosmrs           = { version = "0.15.0", features = [ "cosmwasm", "rpc" ] }
 cosmwasm-std     = { version = "1.5.4", features = [ "abort", "cosmwasm_1_2", "cosmwasm_1_3", "cosmwasm_1_4", "iterator", "stargate" ] }
-prost            = "0.12.3"
+prost            = "0.12.4"
 serde            = "1.0.144"
 serde_json       = "1.0.85"
 tendermint-proto = "0.32.0"


### PR DESCRIPTION
Tl;dr use the v0.1.8 version of injective-std

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated dependencies to the latest versions for improved stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->